### PR TITLE
去除cn域名屏蔽，新增广告域名屏蔽

### DIFF
--- a/V2bX.sh
+++ b/V2bX.sh
@@ -686,7 +686,7 @@ EOF
     # 创建 route.json 文件
     cat <<EOF > /etc/V2bX/route.json
     {
-        "domainStrategy": "AsIs",
+        "domainStrategy": "IPIfNonMatch",
         "rules": [
             {
                 "type": "field",

--- a/V2bX.sh
+++ b/V2bX.sh
@@ -707,7 +707,7 @@ EOF
                 "type": "field",
                 "outboundTag": "block",
                 "domain": [
-                    "geosite:cn"
+                    "geosite:private"
                 ]
             },
             {

--- a/initconfig.sh
+++ b/initconfig.sh
@@ -328,7 +328,7 @@ EOF
     # 创建 route.json 文件
     cat <<EOF > /etc/V2bX/route.json
     {
-        "domainStrategy": "AsIs",
+        "domainStrategy": "IPIfNonMatch",
         "rules": [
             {
                 "type": "field",

--- a/initconfig.sh
+++ b/initconfig.sh
@@ -349,7 +349,7 @@ EOF
                 "type": "field",
                 "outboundTag": "block",
                 "domain": [
-                    "geosite:cn"
+                    "geosite:private"
                 ]
             },
             {


### PR DESCRIPTION
CN域名屏蔽在实际应用中会导致一系列网站无法正常使用
且缺少屏蔽广告域名